### PR TITLE
Added myself to manifesto

### DIFF
--- a/manifesto.txt
+++ b/manifesto.txt
@@ -138,3 +138,4 @@ Jonas Wielicki, operator of federated private XMPP servers
 Fran García, NekBot Developer and nekmo.org operator
 Dennis Schubert, operator of dsx.cc and developer of Jabberry
 Ludovic Bocquet, XMPP server operator
+Danilo Bargen, XMPP server operator


### PR DESCRIPTION
I run a private XMPP server (=no public registration, but connected to XMPP network).

I think "regular" server operators should also have a way to show their commitment to a more secure network. Ubiquitous S2S encryption won't work if not all servers support it. Therefore it is important that not only the public service providers adhere to these guidelines/goals, but also people that just run XMPP servers for themselves & friends.

If you want to differentiate between public service providers and "private or unimportant service providers", why not create two different sections for the signatures? :)

Thanks for creating this manifesto, it's an important step towards more secure communication online!
